### PR TITLE
Add AR F1 track demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,6 @@ el juego de f1 de ar
 
 ## Demo HTML
 
-Se añadió `index.html` con una demostración básica de realidad aumentada usando A-Frame y AR.js. Permite grabar un circuito con GPS y reproducirlo. Para abrirlo solo necesitas un navegador con soporte WebXR y permiso de geolocalización.
+`index.html` permite grabar un circuito GPS, marcar pits y realizar una carrera sencilla con los veinte autos de Fórmula&nbsp;1.
+El proyecto utiliza A‑Frame y AR.js, por lo que basta contar con un navegador compatible con WebXR y conceder permisos de cámara y geolocalización.
 

--- a/README.md
+++ b/README.md
@@ -8,3 +8,24 @@ El auto elegido por el jugador se muestra con su modelo correspondiente y la pis
 grabada se dibuja como una línea amarilla para que los vehículos de la IA la sigan.
 El proyecto utiliza A‑Frame y AR.js, por lo que basta contar con un navegador
 compatible con WebXR y conceder permisos de cámara y geolocalización.
+
+## Modelos F1 2024
+
+<iframe width="640" height="480" src="https://sketchfab.com/playlists/embed?collection=8d257e67f6944038b118f6738fc84092&autostart=1"
+        title="F1 2024"
+        frameborder="0"
+        allowfullscreen
+        mozallowfullscreen="true"
+        webkitallowfullscreen="true"
+        allow="autoplay; fullscreen; xr-spatial-tracking"
+        xr-spatial-tracking
+        execution-while-out-of-viewport
+        execution-while-not-rendered
+        web-share
+    ></iframe>
+    <p style="font-family: sans-serif;font-size: 13px; font-weight: normal; margin: 5px; color: #4A4A4A;">
+        <a href="https://sketchfab.com/sarvesh903/collections/f1-2024-8d257e67f6944038b118f6738fc84092" target="_blank" rel="nofollow" style="font-weight: bold; color: #1CAAD9;">F1 2024</a>
+        by <a href="https://sketchfab.com/sarvesh903" target="_blank" rel="nofollow" style="font-weight: bold; color: #1CAAD9;">sarvesh777</a>
+        on <a href="https://sketchfab.com?utm_source=website&utm_medium=embed&utm_campaign=share-popup" target="_blank" rel="nofollow" style="font-weight: bold; color: #1CAAD9;">Sketchfab</a>
+    </p>
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ el juego de f1 de ar
 
 ## Demo HTML
 
-`index.html` permite grabar un circuito GPS, marcar pits y realizar una carrera sencilla con los veinte autos de Fórmula&nbsp;1.
-El proyecto utiliza A‑Frame y AR.js, por lo que basta contar con un navegador compatible con WebXR y conceder permisos de cámara y geolocalización.
-
+`index.html` permite grabar un circuito GPS, marcar pits y realizar una carrera sencilla con los veinte autos de Fórmula 1.
+El auto elegido por el jugador se muestra con su modelo correspondiente y la pista
+grabada se dibuja como una línea amarilla para que los vehículos de la IA la sigan.
+El proyecto utiliza A‑Frame y AR.js, por lo que basta contar con un navegador
+compatible con WebXR y conceder permisos de cámara y geolocalización.

--- a/index.html
+++ b/index.html
@@ -65,9 +65,7 @@
       <a-asset-item id="bottas" src="models/f1/alfa%20romeo/vottas/vottas.obj"></a-asset-item>
       <a-asset-item id="zhou" src="models/f1/alfa%20romeo/zhou/zhou.obj"></a-asset-item>
     </a-assets>
-    <a-entity id="player-car" gps-entity-place="latitude:0; longitude:0" rotation="0 0 0" scale="0.5 0.5 0.5">
-      <a-box depth="1" height="0.3" width="0.5" color="red"></a-box>
-    </a-entity>
+    <a-entity id="player-car" gps-entity-place="latitude:0; longitude:0" rotation="0 0 0" scale="0.5 0.5 0.5"></a-entity>
   </a-scene>
 <script>
 const teams = [
@@ -153,8 +151,29 @@ startRaceBtn.onclick=function(){
   lapEl.textContent='0';
   statusEl.textContent='Carrera iniciada';
   const player=document.getElementById('player-car');
+  const playerId=teams[parseInt(select.value,10)].driver.toLowerCase();
+  player.setAttribute('obj-model',`obj:#${playerId}`);
   const ai=[];
   const scene=document.querySelector('a-scene');
+  const start=saved[0];
+  const path=document.createElement('a-entity');
+  path.setAttribute('gps-entity-place',`latitude:${start.lat};longitude:${start.lon}`);
+  const pts=saved.map(pt=>{
+    const dx=(pt.lon-start.lon)*111320*Math.cos(start.lat*Math.PI/180);
+    const dz=-(pt.lat-start.lat)*111320;
+    return `${dx} 0 ${dz}`;
+  }).join(',');
+  path.setAttribute('line',`color: yellow; path: ${pts}`);
+  scene.appendChild(path);
+  pitPos.forEach((p,i)=>{
+    const pit=document.createElement('a-box');
+    pit.setAttribute('gps-entity-place',`latitude:${p.lat};longitude:${p.lon}`);
+    pit.setAttribute('width','1');
+    pit.setAttribute('height','0.2');
+    pit.setAttribute('depth','2');
+    pit.setAttribute('color','blue');
+    scene.appendChild(pit);
+  });
   teams.forEach((t,i)=>{
     if(i===parseInt(select.value,10))return; // skip player
     const mId=t.driver.toLowerCase();

--- a/index.html
+++ b/index.html
@@ -29,12 +29,42 @@
     <label>Equipo/Piloto:
       <select id="car-select"></select>
     </label>
+    <label>Vueltas:
+      <input id="laps" type="number" value="3" min="1" style="width:60px;">
+    </label>
     <button id="record-btn">Comenzar grabación</button>
     <button id="stop-btn" disabled>Detener</button>
+    <button id="add-pit" disabled>Marcar pit</button>
     <button id="start-race" disabled>Iniciar carrera</button>
     <span id="status"></span>
   </div>
+  <div id="hud" style="position:fixed;bottom:10px;left:10px;color:white;z-index:10;font-family:sans-serif;">
+    Vuelta <span id="lap">0</span>
+  </div>
   <a-scene embedded arjs="sourceType: webcam;" renderer="logarithmicDepthBuffer: true">
+    <a-assets>
+      <!-- modelos de autos. Sube estos archivos a la misma estructura en tu servidor -->
+      <a-asset-item id="verstappen" src="models/f1/red%20bull/vertappen/verstappen.obj"></a-asset-item>
+      <a-asset-item id="perez" src="models/f1/red%20bull/player/player.obj"></a-asset-item>
+      <a-asset-item id="leclerc" src="models/f1/ferrari/leclerc/leclerc.obj"></a-asset-item>
+      <a-asset-item id="sainz" src="models/f1/ferrari/sainz/SAINZ.obj"></a-asset-item>
+      <a-asset-item id="hamilton" src="models/f1/mercedes/hamilton/hamilton.obj"></a-asset-item>
+      <a-asset-item id="russell" src="models/f1/mercedes/russell/russell.obj"></a-asset-item>
+      <a-asset-item id="norris" src="models/f1/mclaren/Norris/norris.obj"></a-asset-item>
+      <a-asset-item id="piastri" src="models/f1/mclaren/Piastri/piastri.obj"></a-asset-item>
+      <a-asset-item id="alonso" src="models/f1/aston%20martin/alonso/alonso.obj"></a-asset-item>
+      <a-asset-item id="stroll" src="models/f1/aston%20martin/stroll/stroll.obj"></a-asset-item>
+      <a-asset-item id="ocon" src="models/f1/alpine/ocon/ocon.obj"></a-asset-item>
+      <a-asset-item id="gasly" src="models/f1/alpine/gasly/GASLY.obj"></a-asset-item>
+      <a-asset-item id="albon" src="models/f1/williams/albon/albon.obj"></a-asset-item>
+      <a-asset-item id="sargeant" src="models/f1/williams/sargent/sargent.obj"></a-asset-item>
+      <a-asset-item id="tsunoda" src="models/f1/alphaturi/tsunoda/tsunoda.obj"></a-asset-item>
+      <a-asset-item id="ricciardo" src="models/f1/alphaturi/riccardo/riccardo.obj"></a-asset-item>
+      <a-asset-item id="magnussen" src="models/f1/haas/magnussen/magnussen.obj"></a-asset-item>
+      <a-asset-item id="hulkenberg" src="models/f1/haas/hulkemberg/hulkemberg.obj"></a-asset-item>
+      <a-asset-item id="bottas" src="models/f1/alfa%20romeo/vottas/vottas.obj"></a-asset-item>
+      <a-asset-item id="zhou" src="models/f1/alfa%20romeo/zhou/zhou.obj"></a-asset-item>
+    </a-assets>
     <a-entity id="player-car" gps-entity-place="latitude:0; longitude:0" rotation="0 0 0" scale="0.5 0.5 0.5">
       <a-box depth="1" height="0.3" width="0.5" color="red"></a-box>
     </a-entity>
@@ -71,16 +101,22 @@ teams.forEach((t,i)=>{
 });
 let recording=false;
 let track=[];
+let pits=[];
 let watchId=null;
 const statusEl=document.getElementById('status');
 const recordBtn=document.getElementById('record-btn');
 const stopBtn=document.getElementById('stop-btn');
 const startRaceBtn=document.getElementById('start-race');
+const addPitBtn=document.getElementById('add-pit');
+const lapCountInput=document.getElementById('laps');
+const lapEl=document.getElementById('lap');
 recordBtn.onclick=function(){
   track=[];
+  pits=[];
   recording=true;
   startRaceBtn.disabled=true;
   stopBtn.disabled=false;
+  addPitBtn.disabled=false;
   recordBtn.disabled=true;
   statusEl.textContent='Grabando circuito...';
   if(navigator.geolocation){
@@ -95,21 +131,60 @@ stopBtn.onclick=function(){
   navigator.geolocation.clearWatch(watchId);
   stopBtn.disabled=true;
   recordBtn.disabled=false;
+  addPitBtn.disabled=true;
   startRaceBtn.disabled=track.length<2;
   statusEl.textContent=`Circuito grabado: ${track.length} puntos`;
   localStorage.setItem('f1-track',JSON.stringify(track));
+  localStorage.setItem('f1-pits',JSON.stringify(pits));
+};
+addPitBtn.onclick=function(){
+  if(!track.length)return;
+  const last=track[track.length-1];
+  pits.push(last);
+  statusEl.textContent=`Pits marcados: ${pits.length}`;
 };
 startRaceBtn.onclick=function(){
   const saved=JSON.parse(localStorage.getItem('f1-track')||'[]');
+  const pitPos=JSON.parse(localStorage.getItem('f1-pits')||'[]');
   if(!saved.length){alert('No hay circuito');return;}
+  const laps=parseInt(lapCountInput.value,10)||1;
+  let lap=0;
   let idx=0;
+  lapEl.textContent='0';
   statusEl.textContent='Carrera iniciada';
   const player=document.getElementById('player-car');
+  const ai=[];
+  const scene=document.querySelector('a-scene');
+  teams.forEach((t,i)=>{
+    if(i===parseInt(select.value,10))return; // skip player
+    const mId=t.driver.toLowerCase();
+    const car=document.createElement('a-entity');
+    car.setAttribute('gps-entity-place','latitude:0;longitude:0');
+    car.setAttribute('scale','0.5 0.5 0.5');
+    car.setAttribute('obj-model',`obj:#${mId}`);
+    scene.appendChild(car);
+    ai.push({el:car,idx:-5*i});
+  });
   function move(){
-    if(idx>=saved.length){statusEl.textContent='Carrera finalizada';return;}
+    if(lap>=laps){
+      statusEl.textContent='Carrera finalizada';
+      return;
+    }
     const p=saved[idx];
     player.setAttribute('gps-entity-place',`latitude:${p.lat};longitude:${p.lon}`);
-    idx++;setTimeout(move,1000);
+    ai.forEach(c=>{
+      const aiIdx=(c.idx+saved.length)%saved.length;
+      const pt=saved[aiIdx];
+      c.el.setAttribute('gps-entity-place',`latitude:${pt.lat};longitude:${pt.lon}`);
+      c.idx++;
+    });
+    idx++;
+    if(idx>=saved.length){
+      idx=0;
+      lap++;
+      lapEl.textContent=lap;
+    }
+    setTimeout(move,1000);
   }
   move();
 };


### PR DESCRIPTION
## Summary
- add menu options for laps and pits
- include asset links for 20 F1 car models
- implement simple GPS recording with pit markers
- spawn AI cars that follow the recorded track
- update README with new description

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d63f81508832fba5cbb3faa7af489