### PR TITLE
Add AR racing game HTML with improved leaderboard progress calculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,719 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <title>F1 AR Racing V15 (GLB Edition)</title>
+    <style>
+        /* Estilos generales y para la superposición de la UI */
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+            color: white;
+            background-color: #111;
+            overflow: hidden;
+        }
+        #ar-container {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+        }
+        #ui-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            text-align: center;
+            z-index: 10;
+            pointer-events: none; 
+        }
+        .ui-panel {
+            background: rgba(0, 0, 0, 0.8);
+            padding: 20px;
+            border-radius: 15px;
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            box-shadow: 0 4px 30px rgba(0, 0, 0, 0.5);
+            backdrop-filter: blur(5px);
+            -webkit-backdrop-filter: blur(5px);
+            max-width: 90%;
+            pointer-events: auto;
+        }
+        button, input {
+            pointer-events: auto;
+        }
+        button {
+            background: #e10600; /* Color rojo F1 */
+            color: white;
+            border: none;
+            padding: 15px 30px;
+            font-size: 1.2em;
+            font-weight: bold;
+            border-radius: 10px;
+            cursor: pointer;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            margin-top: 20px;
+            transition: transform 0.2s ease, background-color 0.2s ease;
+        }
+        button:hover {
+            transform: scale(1.05);
+            background: #ff160d;
+        }
+        #message-box {
+            font-size: 1.5em;
+            font-weight: bold;
+            text-shadow: 0 0 10px black;
+            padding: 0 20px;
+        }
+        #countdown {
+            font-size: 8em;
+            font-weight: bold;
+            text-shadow: 0 0 20px black;
+        }
+        .hidden { display: none !important; }
+        #controls {
+            position: fixed;
+            bottom: 20px;
+            width: 100%;
+            display: flex;
+            justify-content: space-around;
+            align-items: center;
+            z-index: 20;
+            pointer-events: auto;
+        }
+        .control-button {
+            width: 80px; height: 80px;
+            background: rgba(0, 110, 255, 0.5);
+            border: 2px solid rgba(255, 255, 255, 0.7);
+            border-radius: 50%;
+            font-size: 1em; font-weight: bold; color: white;
+            display: flex; justify-content: center; align-items: center;
+            pointer-events: auto;
+        }
+        #incident-button {
+            background: rgba(255, 193, 7, 0.6); /* Amarillo para incidente */
+        }
+        #debug-console {
+            position: fixed; top: 10px; left: 10px;
+            width: calc(100% - 20px); max-height: 150px;
+            background: rgba(0,0,0,0.6); color: #00ff00;
+            font-family: monospace; font-size: 10px;
+            padding: 5px; overflow-y: scroll; z-index: 999;
+            pointer-events: none; border-radius: 5px;
+        }
+        #race-hud {
+            position: fixed; top: 20px; left: 20px; right: 20px;
+            display: flex; justify-content: space-between;
+            z-index: 15; pointer-events: none; font-size: 1.2em;
+            text-shadow: 0 0 5px black;
+        }
+        #leaderboard {
+            background: rgba(0,0,0,0.5); padding: 10px;
+            border-radius: 10px; text-align: left;
+        }
+        #leaderboard ol { margin: 0; padding-left: 25px; }
+        #leaderboard li { font-weight: bold; }
+        #lap-counter {
+            background: rgba(0,0,0,0.5); padding: 10px 15px;
+            border-radius: 10px; font-weight: bold;
+        }
+        #lap-selector-panel input {
+            width: 80px; font-size: 1.5em; text-align: center;
+            margin: 10px;
+        }
+    </style>
+</head>
+<body>
+    <div id="debug-console"></div>
+    <div id="ar-container"></div>
+    <div id="ui-overlay">
+        <!-- El contenido de la UI se generará aquí por JavaScript -->
+    </div>
+    <div id="race-hud" class="hidden">
+        <div id="leaderboard"><ol id="position-list"></ol></div>
+        <div id="lap-counter">Vuelta: 0 / 0</div>
+    </div>
+    <div id="controls" class="hidden">
+        <button id="pit-stop-button" class="control-button">PITS</button>
+        <button id="incident-button" class="control-button">🚩</button>
+    </div>
+
+    <script type="importmap">
+        { "imports": { "three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js", "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/" } }
+    </script>
+
+    <script type="module">
+        import * as THREE from 'three';
+        import { ARButton } from 'three/addons/webxr/ARButton.js';
+        import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+
+        let camera, scene, renderer, reticle, hitTestSource = null, hitTestSourceRequested = false;
+        let gameState = 'MENU';
+        const trackPoints = [];
+        let trackLine = null, raceTrackCurve = null;
+        const cars = [];
+        let playerCar = null;
+        const pitBoxes = [];
+        let totalLaps = 3;
+        let finishLine = { plane: null, mesh: null };
+        let lastPlayerPos = new THREE.Vector3();
+        let playerStartMarker = null;
+        let placementCounter = 0;
+
+        const ui = {
+            overlay: document.getElementById('ui-overlay'),
+            debugConsole: document.getElementById('debug-console'),
+            raceHud: document.getElementById('race-hud'),
+            positionList: document.getElementById('position-list'),
+            lapCounter: document.getElementById('lap-counter'),
+            controls: document.getElementById('controls')
+        };
+
+        function log(message) { console.log(message); ui.debugConsole.innerHTML += `> ${message}<br>`; ui.debugConsole.scrollTop = ui.debugConsole.scrollHeight; }
+
+        // --- NUEVA ESTRUCTURA DE EQUIPOS Y MODELOS ---
+        const teams = [
+            { team: 'Red Bull', file: 'redbull.glb', drivers: ['Player', 'Verstappen'] },
+            { team: 'Mercedes', file: 'mercedes.glb', drivers: ['Hamilton', 'Russell'] },
+            { team: 'Ferrari', file: 'ferrari.glb', drivers: ['Leclerc', 'Sainz'] },
+            { team: 'McLaren', file: 'mclaren.glb', drivers: ['Norris', 'Piastri'] },
+            { team: 'Aston Martin', file: 'astonmartin.glb', drivers: ['Alonso', 'Stroll'] },
+            { team: 'Alpine', file: 'alpine.glb', drivers: ['Gasly', 'Ocon'] },
+            { team: 'Williams', file: 'williams.glb', drivers: ['Albon', 'Sargent'] },
+            { team: 'RB', file: 'RB.glb', drivers: ['Tsunoda', 'Ricciardo'] },
+            { team: 'Sauber', file: 'sauber.glb', drivers: ['Bottas', 'Zhou'] },
+            { team: 'Haas', file: 'haas.glb', drivers: ['Magnussen', 'Hulkenberg'] }
+        ];
+
+        init();
+
+        function init() {
+            log('Initializing scene...');
+            const container = document.getElementById('ar-container');
+            scene = new THREE.Scene();
+            camera = new THREE.PerspectiveCamera(70, window.innerWidth / window.innerHeight, 0.01, 40);
+            scene.add(new THREE.HemisphereLight(0xffffff, 0xbbbbff, 3));
+            const directionalLight = new THREE.DirectionalLight(0xffffff, 3);
+            directionalLight.position.set(0, 10, 0);
+            scene.add(directionalLight);
+            renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+            renderer.setPixelRatio(window.devicePixelRatio);
+            renderer.setSize(window.innerWidth, window.innerHeight);
+            renderer.xr.enabled = true;
+            container.appendChild(renderer.domElement);
+            reticle = new THREE.Mesh(new THREE.RingGeometry(0.15, 0.2, 32).rotateX(-Math.PI / 2), new THREE.MeshBasicMaterial());
+            reticle.matrixAutoUpdate = false;
+            reticle.visible = false;
+            scene.add(reticle);
+            window.addEventListener('resize', () => {
+                camera.aspect = window.innerWidth / window.innerHeight;
+                camera.updateProjectionMatrix();
+                renderer.setSize(window.innerWidth, window.innerHeight);
+            });
+            changeState('MENU');
+        }
+
+        async function loadModels() {
+            const loader = new GLTFLoader();
+            const loadPromises = teams.map(team => {
+                return new Promise(async (resolve) => {
+                    try {
+                        const gltf = await loader.loadAsync(`./models/f1/${team.file}`);
+                        log(`<span style="color: lightgreen;">SUCCESS: Loaded team model ${team.file}</span>`);
+                        // Crear dos coches por cada modelo cargado
+                        for (let i = 0; i < 2; i++) {
+                            const driverName = team.drivers[i];
+                            const model = i === 0 ? gltf.scene : gltf.scene.clone(); // Clonar para el segundo coche
+                            model.scale.set(0.6, 0.6, 0.6);
+                            model.visible = false;
+                            scene.add(model);
+                            const carData = {
+                                name: driverName, model: model, laps: 0, progress: 0, speed: 0,
+                                isPlayer: driverName === 'Player', gridPosition: new THREE.Vector3(), gridQuaternion: new THREE.Quaternion(),
+                                state: 'IDLE', pitTimeout: 0
+                            };
+                            if (carData.isPlayer) {
+                                playerCar = carData;
+                            } else {
+                                cars.push(carData);
+                            }
+                        }
+                    } catch (error) {
+                        log(`<span style="color: red;">ERROR loading ${team.file}. Creating placeholders.</span>`);
+                        console.error(error);
+                        // Crear placeholders si el modelo del equipo falla
+                        for (const driverName of team.drivers) {
+                            const placeholder = new THREE.Mesh(new THREE.BoxGeometry(3.4, 0.7, 1.2), new THREE.MeshStandardMaterial({ color: 0xcccccc }));
+                            placeholder.scale.set(0.6, 0.6, 0.6);
+                            placeholder.visible = false;
+                            scene.add(placeholder);
+                            const carData = {
+                                name: driverName, model: placeholder, laps: 0, progress: 0, speed: 0,
+                                isPlayer: driverName === 'Player', gridPosition: new THREE.Vector3(), gridQuaternion: new THREE.Quaternion(),
+                                state: 'IDLE', pitTimeout: 0
+                            };
+                            if (carData.isPlayer) { playerCar = carData; } else { cars.push(carData); }
+                        }
+                    }
+                    resolve();
+                });
+            });
+            await Promise.all(loadPromises);
+            changeState('SCANNING_TRACK');
+        }
+
+        function setUI(html, listeners = {}) {
+            ui.overlay.innerHTML = html;
+            for (const id in listeners) {
+                const element = document.getElementById(id);
+                if (element) {
+                    element.addEventListener('click', listeners[id]);
+                }
+            }
+        }
+
+        function changeState(newState) {
+            log(`State -> ${newState}`);
+            gameState = newState;
+            if (reticle) reticle.visible = false;
+            ui.raceHud.classList.add('hidden');
+            ui.controls.classList.add('hidden');
+
+            switch (gameState) {
+                case 'MENU':
+                    setUI(
+                        `<div class="ui-panel">
+                            <h1>F1 AR Racing</h1>
+                            <p>Crea un circuito en el mundo real y compite contra los mejores.</p>
+                            <button id="start-ar-button">Comenzar</button>
+                         </div>`,
+                        { 'start-ar-button': () => {
+                            const arButton = ARButton.createButton(renderer, { requiredFeatures: ['hit-test', 'dom-overlay'], domOverlay: { root: document.body } });
+                            document.getElementById('start-ar-button').parentElement.replaceWith(arButton);
+                            renderer.xr.addEventListener('sessionstart', () => {
+                                log("AR Session Started Successfully!");
+                                renderer.setAnimationLoop(render);
+                                changeState('LOADING');
+                            });
+                        }}
+                    );
+                    break;
+                case 'LOADING':
+                    setUI(`<div class="ui-panel"><p>Cargando modelos de F1...</p></div>`);
+                    loadModels();
+                    break;
+                case 'SCANNING_TRACK':
+                    setUI(
+                        `<div class="ui-panel">
+                            <p id="message-box">Dibuja la pista caminando.</p>
+                            <button id="action-button">Finalizar Pista</button>
+                         </div>`,
+                        { 'action-button': onActionButtonClick }
+                    );
+                    if (reticle) { reticle.visible = true; reticle.material.color.set(0x00ff00); }
+                    break;
+                case 'SETUP_LAPS':
+                    setUI(
+                        `<div class="ui-panel">
+                            <h2>Número de Vueltas</h2>
+                            <input type="number" id="lap-input" value="3" min="1" max="10">
+                            <button id="confirm-laps-button">Confirmar</button>
+                         </div>`,
+                        { 'confirm-laps-button': onConfirmLapsClick }
+                    );
+                    break;
+                case 'SETUP_PITS':
+                    placementCounter = 0;
+                    setUI(
+                        `<div class="ui-panel">
+                            <p id="message-box">Coloca el Pit #${placementCounter + 1}</p>
+                            <button id="action-button">Colocar Pit</button>
+                         </div>`,
+                        { 'action-button': onActionButtonClick }
+                    );
+                    if (reticle) { reticle.visible = true; reticle.material.color.set(0x0000ff); }
+                    break;
+                case 'SETUP_FINISH_LINE':
+                    setUI(
+                        `<div class="ui-panel">
+                            <p id="message-box">Coloca la Línea de Meta</p>
+                            <button id="action-button">Colocar</button>
+                         </div>`,
+                        { 'action-button': onActionButtonClick }
+                    );
+                    if (reticle) { reticle.visible = true; reticle.material.color.set(0xffffff); }
+                    break;
+                case 'SETUP_GRID':
+                    placementCounter = 0;
+                    const allCars = [playerCar, ...cars];
+                    setUI(
+                        `<div class="ui-panel">
+                            <p id="message-box">Coloca la Posición #1 (${allCars[0].name})</p>
+                            <button id="action-button">Colocar</button>
+                         </div>`,
+                        { 'action-button': onActionButtonClick }
+                    );
+                    if (reticle) { reticle.visible = true; reticle.material.color.set(0xffa500); }
+                    break;
+                case 'PRE_RACE_TIMER':
+                    setUI(
+                        `<div class="ui-panel">
+                            <p id="message-box">La carrera comienza en:</p>
+                            <p id="countdown" style="font-size: 8em; font-weight: bold;"></p>
+                         </div>`
+                    );
+                    playerCar.state = 'PRE_RACE'; 
+                    startPreRaceTimer();
+                    break;
+                case 'FORMATION_LAP':
+                    setUI(`<div class="ui-panel"><p>Vuelta de Formación</p></div>`);
+                    ui.raceHud.classList.remove('hidden');
+                    startFormationLap();
+                    break;
+                case 'AWAITING_PLAYER_POSITION':
+                    setUI(`<div class="ui-panel"><p>Vuelve a tu posición en la parrilla.</p></div>`);
+                    if (playerStartMarker) playerStartMarker.visible = true;
+                    ui.raceHud.classList.remove('hidden');
+                    break;
+                case 'RACE_COUNTDOWN':
+                    setUI(
+                        `<div class="ui-panel">
+                            <p id="message-box">¡Prepárate!</p>
+                            <p id="countdown" style="font-size: 8em; font-weight: bold;"></p>
+                         </div>`
+                    );
+                    ui.raceHud.classList.remove('hidden');
+                    startRaceCountdown();
+                    break;
+                case 'RACE':
+                    setUI('');
+                    ui.raceHud.classList.remove('hidden');
+                    ui.controls.classList.remove('hidden');
+                    document.getElementById('pit-stop-button').addEventListener('click', () => { playerCar.state = 'PITTING'; });
+                    document.getElementById('incident-button').addEventListener('click', () => { changeState('RED_FLAG'); });
+                    break;
+                case 'RED_FLAG':
+                    setUI(`<div class="ui-panel" style="background: rgba(255,0,0,0.7);"><p style="font-size: 3em; font-weight: bold;">BANDERA ROJA</p></div>`);
+                    triggerRedFlag();
+                    break;
+                case 'RACE_OVER':
+                    setUI(`<div class="ui-panel"><p>¡Carrera Terminada!</p></div>`);
+                    ui.raceHud.classList.remove('hidden');
+                    break;
+            }
+        }
+
+        function onConfirmLapsClick() {
+            const lapInput = document.getElementById('lap-input');
+            totalLaps = parseInt(lapInput.value) || 3;
+            log(`Laps set to: ${totalLaps}`);
+            changeState('SETUP_PITS');
+        }
+
+        function onActionButtonClick() {
+            if (!reticle.visible) { log("Action clicked but reticle not visible."); return; }
+            log(`Action button clicked in state: ${gameState}`);
+
+            if (gameState === 'SCANNING_TRACK' && trackPoints.length > 5) {
+                trackPoints.push(trackPoints[0].clone()); updateTrackLine();
+                raceTrackCurve = new THREE.CatmullRomCurve3(trackPoints, true, 'catmullrom', 0.5);
+                changeState('SETUP_LAPS');
+            } else if (gameState === 'SETUP_PITS') {
+                placeNextPit();
+            } else if (gameState === 'SETUP_FINISH_LINE') {
+                placeFinishLine();
+            } else if (gameState === 'SETUP_GRID') {
+                placeNextGridPosition();
+            }
+        }
+        
+        function placeNextPit() {
+            const pitBox = new THREE.Object3D();
+            pitBox.position.setFromMatrixPosition(reticle.matrix);
+            pitBox.quaternion.setFromRotationMatrix(reticle.matrix);
+            scene.add(pitBox);
+            pitBoxes.push(pitBox);
+            placementCounter++;
+            if (placementCounter >= 20) {
+                log('All pits placed.');
+                changeState('SETUP_FINISH_LINE');
+            } else {
+                document.getElementById('message-box').textContent = `Coloca el Pit #${placementCounter + 1}`;
+            }
+        }
+
+        function placeFinishLine() {
+            const finishLinePosition = new THREE.Vector3().setFromMatrixPosition(reticle.matrix);
+            const finishLineQuaternion = new THREE.Quaternion().setFromRotationMatrix(reticle.matrix);
+            const finishLineNormal = new THREE.Vector3(0, 0, 1).applyQuaternion(finishLineQuaternion);
+            finishLine.plane = new THREE.Plane(finishLineNormal, 0);
+            finishLine.plane.translate(finishLinePosition);
+            const textureLoader = new THREE.TextureLoader();
+            const checkerboardTexture = textureLoader.load('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAHklEQVQ4jWNgYGD4Twzu6KkBjgA2BUWHI76GqlsMAA8PAAbn9a/pAAAAAElFTSuQmCC');
+            checkerboardTexture.wrapS = THREE.RepeatWrapping;
+            checkerboardTexture.wrapT = THREE.RepeatWrapping;
+            checkerboardTexture.repeat.set(4, 8);
+            const finishLineMat = new THREE.MeshBasicMaterial({ map: checkerboardTexture, transparent: true, opacity: 0.7, side: THREE.DoubleSide });
+            const finishLineGeo = new THREE.PlaneGeometry(3.5, 7);
+            finishLine.mesh = new THREE.Mesh(finishLineGeo, finishLineMat);
+            finishLine.mesh.position.copy(finishLinePosition);
+            finishLine.mesh.quaternion.copy(finishLineQuaternion);
+            finishLine.mesh.rotateX(Math.PI / 2);
+            scene.add(finishLine.mesh);
+            log('Finish line placed.');
+            changeState('SETUP_GRID');
+        }
+
+        function placeNextGridPosition() {
+            const allCars = [playerCar, ...cars];
+            const carToPlace = allCars[placementCounter];
+            carToPlace.model.position.setFromMatrixPosition(reticle.matrix);
+            carToPlace.model.quaternion.setFromRotationMatrix(reticle.matrix);
+            carToPlace.gridPosition.copy(carToPlace.model.position);
+            carToPlace.gridQuaternion.copy(carToPlace.model.quaternion);
+            carToPlace.model.visible = true;
+            carToPlace.state = 'ON_GRID';
+            if (carToPlace.isPlayer) {
+                playerStartMarker = new THREE.Mesh(new THREE.PlaneGeometry(2, 4), new THREE.MeshBasicMaterial({ color: 0xffff00, transparent: true, opacity: 0.5, side: THREE.DoubleSide }));
+                playerStartMarker.position.copy(playerCar.gridPosition);
+                playerStartMarker.quaternion.copy(playerCar.gridQuaternion);
+                playerStartMarker.rotateX(Math.PI / 2);
+                playerStartMarker.visible = false;
+                scene.add(playerStartMarker);
+            }
+            placementCounter++;
+            if (placementCounter >= allCars.length) {
+                log('All grid positions placed.');
+                changeState('PRE_RACE_TIMER');
+            } else {
+                document.getElementById('message-box').textContent = `Coloca la Posición #${placementCounter + 1} (${allCars[placementCounter].name})`;
+            }
+        }
+
+        function startPreRaceTimer() {
+            let timer = 60;
+            const countdownEl = document.getElementById('countdown');
+            const interval = setInterval(() => {
+                if (countdownEl) countdownEl.textContent = timer;
+                timer--;
+                if (timer < 0) {
+                    clearInterval(interval);
+                    changeState('FORMATION_LAP');
+                }
+            }, 1000);
+        }
+
+        function startFormationLap() {
+            log('Starting formation lap...');
+            updateLapCounter('F');
+            cars.forEach(car => { car.state = 'FORMATION_LAP'; car.speed = 0.00005; });
+            playerCar.state = 'FORMATION_LAP';
+        }
+
+        function startRaceCountdown() {
+            if (playerStartMarker) playerStartMarker.visible = false;
+            const countdownEl = document.getElementById('countdown');
+            let count = 23;
+            const interval = setInterval(() => {
+                if (countdownEl) countdownEl.textContent = count > 0 ? count : "¡YA!";
+                count--;
+                if (count < -1) {
+                    clearInterval(interval);
+                    cars.forEach(c => { c.state = 'RACING'; c.speed = 0.00008 + Math.random() * 0.00003; });
+                    playerCar.state = 'RACING';
+                    changeState('RACE');
+                }
+            }, 1000);
+        }
+        
+        function triggerRedFlag() {
+            log("RED FLAG!");
+            cars.forEach(car => { car.state = 'REGRIDDING'; car.speed = 0; });
+            playerCar.state = 'AWAITING_RESTART';
+            setTimeout(() => {
+                changeState('AWAITING_PLAYER_POSITION');
+            }, 5000);
+        }
+
+        function updateTrackLine() {
+            if (trackLine) scene.remove(trackLine);
+            if (trackPoints.length < 2) return;
+            trackLine = new THREE.Line(new THREE.BufferGeometry().setFromPoints(trackPoints), new THREE.LineBasicMaterial({ color: 0x00ff00, linewidth: 5 }));
+            scene.add(trackLine);
+        }
+
+        function updateAI(delta) {
+            if (!raceTrackCurve) return;
+            let allAIsRegridded = true;
+            for (const car of cars) {
+                if (car.state === 'FORMATION_LAP' || car.state === 'RACING') {
+                    if (car.laps > 0 && car.progress > 0.9 && Math.random() < 0.001) {
+                        car.state = 'PITTING';
+                        log(`${car.name} is pitting!`);
+                    }
+                    car.progress += car.speed * delta * 60;
+                    if (car.progress >= 1) {
+                        car.progress -= 1;
+                        if (car.state === 'FORMATION_LAP') { car.state = 'REGRIDDING'; car.speed = 0; }
+                        else { car.laps++; if (car.laps >= totalLaps) changeState('RACE_OVER'); }
+                    }
+                    const newPosition = raceTrackCurve.getPointAt(car.progress);
+                    const tangent = raceTrackCurve.getTangentAt(car.progress).normalize();
+                    const lookAtPosition = new THREE.Vector3().copy(newPosition).add(tangent);
+                    car.model.position.lerp(newPosition, 0.1);
+                    car.model.quaternion.slerp(new THREE.Quaternion().setFromRotationMatrix(new THREE.Matrix4().lookAt(car.model.position, lookAtPosition, new THREE.Vector3(0,1,0))), 0.1);
+                } else if (car.state === 'REGRIDDING') {
+                    car.model.position.lerp(car.gridPosition, 0.05);
+                    car.model.quaternion.slerp(car.gridQuaternion, 0.05);
+                    if (car.model.position.distanceTo(car.gridPosition) < 0.1) car.state = 'ON_GRID';
+                } else if (car.state === 'PITTING') {
+                    const pitBox = pitBoxes[cars.indexOf(car) + 1];
+                    if (pitBox) {
+                        car.model.position.lerp(pitBox.position, 0.05);
+                        if (car.model.position.distanceTo(pitBox.position) < 1) {
+                            car.state = 'IN_PIT';
+                            car.pitTimeout = 5;
+                        }
+                    } else { car.state = 'RACING'; }
+                } else if (car.state === 'IN_PIT') {
+                    car.pitTimeout -= delta;
+                    if (car.pitTimeout <= 0) { car.state = 'RACING'; }
+                }
+                if (car.state !== 'ON_GRID') allAIsRegridded = false;
+            }
+            if (gameState === 'FORMATION_LAP' && allAIsRegridded) {
+                changeState('AWAITING_PLAYER_POSITION');
+            }
+        }
+        
+        function updatePlayerCar(delta) {
+            if (!playerCar) return;
+            if (playerCar.state !== 'ON_GRID') {
+                if (playerCar.state === 'PITTING') {
+                    const pitBox = pitBoxes[0];
+                    if (pitBox) {
+                        playerCar.model.position.lerp(pitBox.position, 0.05);
+                        if (playerCar.model.position.distanceTo(pitBox.position) < 1) {
+                            playerCar.state = 'IN_PIT';
+                            playerCar.pitTimeout = 5;
+                        }
+                    } else { playerCar.state = 'RACING'; }
+                } else if (playerCar.state === 'IN_PIT') {
+                    playerCar.pitTimeout -= delta;
+                    if (playerCar.pitTimeout <= 0) { playerCar.state = 'RACING'; }
+                } else {
+                    const offset = new THREE.Vector3(0, -1.6, 0);
+                    offset.applyMatrix4(camera.matrixWorld);
+                    playerCar.model.position.lerp(offset, 0.8);
+                    const cameraQuaternion = new THREE.Quaternion();
+                    camera.getWorldQuaternion(cameraQuaternion);
+                    const euler = new THREE.Euler().setFromQuaternion(cameraQuaternion, 'YXZ');
+                    playerCar.model.quaternion.setFromEuler(new THREE.Euler(0, euler.y, 0));
+                }
+            }
+
+            if (playerCar.state === 'RACING' && finishLine.plane) {
+                const side = finishLine.plane.distanceToPoint(playerCar.model.position);
+                const lastSide = finishLine.plane.distanceToPoint(lastPlayerPos);
+                if (Math.sign(side) !== Math.sign(lastSide)) {
+                    playerCar.laps++;
+                    updateLapCounter();
+                    if (playerCar.laps >= totalLaps) changeState('RACE_OVER');
+                }
+            }
+            lastPlayerPos.copy(playerCar.model.position);
+        }
+
+        function updateLeaderboard() {
+            const allCars = [...cars, playerCar];
+            if (raceTrackCurve && trackPoints.length > 0) {
+                // Aproximar el progreso del jugador encontrando el punto de la pista más cercano
+                let minDist = Infinity;
+                let closestIndex = 0;
+                for (let i = 0; i < trackPoints.length; i++) {
+                    const dist = playerCar.model.position.distanceTo(trackPoints[i]);
+                    if (dist < minDist) {
+                        minDist = dist;
+                        closestIndex = i;
+                    }
+                }
+                playerCar.progress = closestIndex / trackPoints.length;
+            }
+            allCars.sort((a, b) => (b.laps - a.laps) || (b.progress - a.progress));
+            ui.positionList.innerHTML = '';
+            allCars.forEach((car, index) => {
+                const li = document.createElement('li');
+                li.textContent = `${index + 1}. ${car.name}`;
+                if (car.isPlayer) li.style.color = '#ffc107';
+                ui.positionList.appendChild(li);
+            });
+        }
+
+        function updateLapCounter(text = null) {
+            ui.lapCounter.textContent = text ? `Vuelta: ${text} / ${totalLaps}` : `Vuelta: ${playerCar.laps} / ${totalLaps}`;
+        }
+
+        let lastTime = 0;
+        function render(timestamp, frame) {
+            const delta = (timestamp - (lastTime || timestamp)) / 1000;
+            lastTime = timestamp;
+
+            if (frame) {
+                const referenceSpace = renderer.xr.getReferenceSpace();
+                const session = renderer.xr.getSession();
+                if (!hitTestSourceRequested) {
+                    session.requestReferenceSpace('viewer').then(refSpace => {
+                        session.requestHitTestSource({ space: refSpace }).then(source => { hitTestSource = source; });
+                    });
+                    session.addEventListener('end', () => { window.location.reload(); });
+                    hitTestSourceRequested = true;
+                }
+                if (hitTestSource) {
+                    const hitTestResults = frame.getHitTestResults(hitTestSource);
+                    if (hitTestResults.length) {
+                        const hit = hitTestResults[0];
+                        reticle.visible = true;
+                        reticle.matrix.fromArray(hit.getPose(referenceSpace).transform.matrix);
+                    } else { reticle.visible = false; }
+                }
+            }
+            
+            if (playerCar && (playerCar.state !== 'ON_GRID' || gameState === 'PRE_RACE_TIMER')) {
+                updatePlayerCar(delta);
+            }
+            if(gameState !== 'RACE_OVER' && gameState !== 'RED_FLAG') updateAI(delta);
+
+            if (['FORMATION_LAP', 'AWAITING_PLAYER_POSITION', 'RACE', 'RACE_OVER', 'RED_FLAG'].includes(gameState)) {
+                updateLeaderboard();
+            }
+
+            if (gameState === 'AWAITING_PLAYER_POSITION' && playerStartMarker && playerCar.model.position.distanceTo(playerStartMarker.position) < 2.0) {
+                playerCar.state = 'ON_GRID';
+                playerCar.model.position.lerp(playerCar.gridPosition, 0.1);
+                playerCar.model.quaternion.slerp(playerCar.gridQuaternion, 0.1);
+                if (playerCar.model.position.distanceTo(playerCar.gridPosition) < 0.1) {
+                    changeState('RACE_COUNTDOWN');
+                }
+            }
+            
+            if (gameState === 'SCANNING_TRACK' && reticle.visible) {
+                 const newPoint = new THREE.Vector3().setFromMatrixPosition(reticle.matrix);
+                 if (trackPoints.length === 0 || trackPoints[trackPoints.length - 1].distanceTo(newPoint) > 0.3) {
+                     trackPoints.push(newPoint);
+                     updateTrackLine();
+                 }
+            }
+
+            renderer.render(scene, camera);
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add HTML/JS for AR-based F1 racing demo
- estimate player's position along track using nearest drawn point to avoid runtime errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fc000fd14832f95ba4a6bbad628fe